### PR TITLE
refactor: Reduce modification of Cassandra types & support arrays

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -16,20 +16,7 @@ var ParameterizedSQL = SqlConnector.ParameterizedSQL;
 // var EnumFactory = require('./enumFactory').EnumFactory;
 
 var debug = require('debug')('loopback:connector:cassandra');
-
-function uuidFromString(value) {
-  var ret = null;
-  if (typeof value === 'string' && value.length === 36) {
-    ret = originalFromString(value);
-  } else {
-    // assume it's already Unit8Array[16]
-    ret = value;
-  }
-  return ret;
-}
-
-var originalFromString = cassandra.types.Uuid.fromString;
-cassandra.types.Uuid.fromString = uuidFromString;
+var debugFilter = require('debug')('loopback:connector:cassandra:filter');
 
 /**
  * @module loopback-connector-cassandra
@@ -41,10 +28,13 @@ cassandra.types.Uuid.fromString = uuidFromString;
  */
 exports.initialize = function initializeDataSource(dataSource, callback) {
   dataSource.driver = cassandra; // Provide access to the native driver
-  dataSource.connector = new Cassandra(dataSource, dataSource.settings);
+  dataSource.connector = new Cassandra(dataSource.settings);
   dataSource.connector.dataSource = dataSource;
+  dataSource.setMaxListeners(Infinity);  
 
   defineCassandraTypes(dataSource);
+
+  // dataSource.EnumFactory = EnumFactory; // factory for Enums. Note that currently Enums can not be registered.
 
   if (callback) {
     if (dataSource.settings.lazyConnect) {
@@ -58,7 +48,6 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 };
 
 exports.Cassandra = Cassandra;
-exports.driver = cassandra;
 
 function defineCassandraTypes(dataSource) {
   var modelBuilder = dataSource.modelBuilder;
@@ -74,19 +63,31 @@ function defineCassandraTypes(dataSource) {
   defineType(function Point() {
   });
 
-  defineType(dataSource.driver.types.Uuid.fromString, ['Uuid']);
+  defineType(function Uuid(val) {
+    return (typeof value === 'string' && value.length === 36) ?
+      cassandra.types.Uuid.fromString(val) :
+      val;
+  }, ['Uuid']);
 
+  defineType(function TimeUuid(val) {
+    return (typeof value === 'string' && value.length === 36) ?
+      cassandra.types.TimeUuid.fromString(val) :
+      val;
+  }, ['TimeUuid']);
+
+  defineType(function Tuple(val) {
+    return (Array.isArray(val)) ?
+      cassandra.types.Tuple.fromArray(val) :
+      val;
+  }, ['Tuple']);
 }
 
 /**
  * @constructor
  * Constructor for Cassandra connector
- * @param {Object} client The node-mysql client object
+ * @param {Object} settings The cassandra settings object
  */
-function Cassandra(dataSource, settings) {
-  this.dataSource = dataSource;
-  dataSource.setMaxListeners(Infinity);
-
+function Cassandra(settings) {
   SqlConnector.call(this, 'cassandra', settings);
 }
 
@@ -96,6 +97,7 @@ Cassandra.prototype.connect = function(callback) {
   var self = this;
   var options = generateOptions(this.settings);
   var s = self.settings || {};
+  var debugEnabled = debug.enabled;
 
   if (this.client) {
     if (callback) {
@@ -108,12 +110,12 @@ Cassandra.prototype.connect = function(callback) {
     this.client.connect(function(err) {
       var conn = self.client.controlConnection.connection;
       if (!err) {
-        if (self.debug) {
+        if (debugEnabled) {
           debug('Cassandra connection is established: ' + self.settings || {});
         }
         // conn.close();
       } else {
-        if (self.debug || !callback) {
+        if (debugEnabled || !callback) {
           console.error('Cassandra connection is failed: ' + self.settings || {}, err);
         }
       }
@@ -182,31 +184,30 @@ function generateOptions(settings) {
 Cassandra.prototype.executeSQL = function(cql, params, options, callback) {
   var self = this;
   var client = this.client;
+  var debugEnabled = debug.enabled;
   var db = this.settings.database;
   if (typeof callback !== 'function') {
     throw new Error(g.f('{{callback}} should be a function'));
   }
-  if (debug.enabled) {
+  if (debugEnabled) {
     debug('CQL: %s, params: %j', cql, params);
   }
 
-  function myCallback(err, data) {
-    if (debug.enabled) {
+  function executeCallback(err, data) {
+    if (debugEnabled) {
       if (err) {
         debug('Error: %j', err);
       }
       debug('Data: ', data);
     }
-   return callback && callback(err, data ? data.rows : null);
+    return callback && callback(err, data ? data.rows : null);
   }
 
-  this.client.execute(cql, serialize(params), { prepare : true, readTimeout: 30000 }, myCallback);
+  this.client.execute(cql, this.serialize(params), {prepare: true, readTimeout: 30000}, executeCallback);
 };
 
-Cassandra.prototype.executeCQL = Cassandra.executeSQL;
-
 /**
- * Build a SQL SELECT statement
+ * Build a CQL SELECT statement
  * @param {String} model Model name
  * @param {Object} filter Filter object
  * @param {Object} options Options object
@@ -226,6 +227,21 @@ Cassandra.prototype.buildSelect = function(model, filter, options) {
     }
     if (filter.limit) {
       selectStmt = this.applyPagination(model, selectStmt, filter);
+    }
+    if (debug.enabled) {
+      var keys = Object.keys(filter).filter(function(key) {
+        return key !== 'where';
+      }).filter(function(key) {
+        return key !== 'limit';
+      });
+
+      if (keys.length > 0) {
+        debugFilter(
+          '------------->',
+          keys,
+          '<------------- potentially unsupported filter keys'
+        );
+      }
     }
   }
   selectStmt.merge('ALLOW FILTERING', ' ');
@@ -293,7 +309,6 @@ Cassandra.prototype.generateMissingDefaults = function(model, data) {
 };
 
 Cassandra.prototype._modifyOrCreate = function(model, data, options, fields, cb) {
-  // data = this.generateMissingDefaults(model, data);
   var sql = new ParameterizedSQL('INSERT INTO ' + this.tableEscaped(model));
   var columnValues = fields.columnValues;
   var fieldNames = fields.names;
@@ -309,9 +324,7 @@ Cassandra.prototype._modifyOrCreate = function(model, data, options, fields, cb)
     debug('CQL: %s', sql);
   }
   var idColName = this.idColumn(model);
-  this.execute(sql.sql, serialize(sql.params), options, function(err, data) {
-    return cb(err, data);
-  });
+  this.execute(sql.sql, this.serialize(sql.params), options, cb);
 };
 
 /**
@@ -398,10 +411,7 @@ Cassandra.prototype.buildFields = function(model, data, excludeIds) {
 Cassandra.prototype.replaceOrCreate = function(model, data, options, cb) {
   // data = this.generateMissingDefaults(model, data);
   var fields = this.buildReplaceFields(model, data);
-  this._modifyOrCreate(model, data, options, fields, function(err, date) {
-    // console.log('============= replaceOrCreate:', err, data);
-    return cb(err, data);
-  });
+  this._modifyOrCreate(model, data, options, fields, cb);
 };
 
 /**
@@ -416,10 +426,7 @@ Cassandra.prototype.save =
 Cassandra.prototype.updateOrCreate = function(model, data, options, cb) {
   // data = this.generateMissingDefaults(model, data);
   var fields =  this.buildFields(model, data);
-  this._modifyOrCreate(model, data, options, fields, function(err, date) {
-    // console.log('============= updateOrCreate:', err, data);
-    return cb(err, data);
-  });
+  this._modifyOrCreate(model, data, options, fields, cb);
 };
 
 function dateToMysql(date) {
@@ -464,8 +471,16 @@ Cassandra.prototype.generateValueByColumnType = function(type) {
   return val;
 };
 
-function generateCassandraUuidString() {
-  return cassandra.types.Uuid.random().toString();
+function generateCassandraUuid() {
+  return cassandra.types.Uuid.random();
+}
+
+Cassandra.prototype.generateId = function(client) {
+  return generateCassandraTimeUuid();
+}
+
+function generateCassandraTimeUuid() {
+  return cassandra.types.TimeUuid.now();
 }
 
 /*!
@@ -517,7 +532,6 @@ Cassandra.prototype.toColumnValue = function(prop, val) {
       val = new Date(val);
     }
     return dateToMysql(val);
-    // return dateToNumber(val);
   }
   if (prop.type === Boolean) {
     return !!val;
@@ -528,43 +542,81 @@ Cassandra.prototype.toColumnValue = function(prop, val) {
       params: [val.lat, val.lng],
     });
   }
+  if (prop.type === Buffer) {
+    return val;
+  }
   if (prop.type === Object) {
     return this._serializeObject(val);
   }
+  if (prop.type === Array) {
+    if (typeof val === 'string') {
+      val = JSON.parse(val);
+    }
+    return val;
+  }
+  if (
+    prop.type === cassandra.types.Uuid ||
+    prop.type === 'Uuid' ||
+    prop.type.name === 'Uuid'
+  ) {
+    return (typeof val === 'string') ?
+      new cassandra.types.Uuid.fromString(val) :
+      val;
+  }
+  if (
+    prop.type === cassandra.types.TimeUuid ||
+    prop.type === 'TimeUuid' ||
+    prop.type.name === 'TimeUuid'
+  ) {
+    return (typeof val === 'string') ?
+      new cassandra.types.TimeUuid.fromString(val) :
+      val;
+  }
+  if (
+    prop.type === cassandra.types.Tuple ||
+    prop.type === 'Tuple' ||
+    prop.type.name === 'Tuple'
+  ) {
+    return (Array.isArray(val)) ?
+      new cassandra.types.Tuple.fromArray(val) :
+      val;
+  }
   if (typeof prop.type === 'function') {
-    return prop.type(val);
+    return this._serializeObject(val);
+  }
+  if (Array.isArray(prop.type)) {
+    if (typeof val === 'string') {
+      val = JSON.parse(val);
+    }
+    return val;
   }
   return this._serializeObject(val);
 };
 
-Cassandra.prototype._serializeObject = serializeObject;
-
-function serializeObject(obj) {
+Cassandra.prototype._serializeObject = function(obj) {
   var val;
   if (obj && typeof obj.toJSON === 'function') {
     obj = obj.toJSON();
   }
-  if (obj && typeof obj !== 'string') {
-    // avoid to stringify null and undefined
+  if (typeof obj !== 'string') {
     val = JSON.stringify(obj);
   } else {
     val = obj;
   }
   return val;
-}
+};
 
-function serialize(params) {
+Cassandra.prototype.serialize = function(params) {
+  var self = this;
   var serialized = [];
   params.forEach(function(param) {
-    if (param && typeof param === 'object') {
-      // avoid to stringify null and undefined
-      param = serializeObject(param);
+    if (param && !Array.isArray(param) && typeof param === 'object') {
+      param = self._serializeObject(param);
     }
     serialized.push(param);
   });
   return serialized;
-  // return params;
-}
+};
 
 
 /**
@@ -573,9 +625,7 @@ function serialize(params) {
  * Returns {Function}
  */
 Cassandra.prototype.getDefaultIdType = function(prop) {
-  var Uuid = this.dataSource.driver.types.Uuid.fromString;
-
-  return Uuid;
+  return "Uuid";
 };
 
 /*!
@@ -592,55 +642,81 @@ Cassandra.prototype.fromColumnValue = function(prop, val) {
   var Uuid = this.dataSource.driver.types.Uuid.fromString;
 
   if (prop) {
-    switch (prop.type.name) {
-      case 'Number':
-        val = Number(val);
-        break;
-      case 'String':
-        val = String(val);
-        break;
-      case 'Date':
-
+    if (prop.type.name === 'Number') {
+      val = Number(val);
+    } else if (prop.type.name === 'String') {
+      val = String(val);
+    } else if (prop.type.name === 'Date') {
         // Cassandra allows, unless NO_ZERO_DATE is set, dummy date/time entries
         // new Date() will return Invalid Date for those, so we need to handle
         // those separate.
-        if (val == '0000-00-00 00:00:00') {
-          val = null;
-        } else {
-          val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
-        }
-        break;
-      case 'Boolean':
-        val = Boolean(val);
-        break;
-      case 'GeoPoint':
-      case 'Point':
-        val = {
-          lat: val.x,
-          lng: val.y,
-        };
-        break;
-      case 'Uuid':
+      if (val == '0000-00-00 00:00:00') {
+        val = null;
+      } else {
+        val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+      }
+    } else if (prop.type.name === 'Boolean') {
+      val = Boolean(val);
+    } else if (
+      prop.type.name === 'GeoPoint' ||
+      prop.type.name === 'Point'
+    ) {
+      val = {
+        lat: val.x,
+        lng: val.y,
+      };
+    } else if (
+      prop.type.name === 'List' ||
+      prop.type.name === 'Array' ||
+      prop.type.name === 'Object' ||
+      prop.type.name === 'JSON'
+    ) {
+      if (typeof val === 'string') {
+        val = JSON.parse(val);
+      }
+    } else if (
+      prop.type === cassandra.types.Uuid ||
+      prop.type === 'Uuid' ||
+      prop.type.name === 'Uuid' ||
+      prop.type === cassandra.types.TimeUuid ||
+      prop.type === 'TimeUuid' ||
+      prop.type.name === 'TimeUuid'
+    ) {
+      if (typeof val !== 'string') {
         val = val.toString();
-        break;
-      case 'List':
-      case 'Array':
-      case 'Object':
-      case 'JSON':
+      }
+    } else if (
+      prop.type === cassandra.types.Tuple ||
+      prop.type === 'Tuple' ||
+      prop.type.name === 'Tuple'
+    ) {
+      if (!Array.isArray(val)) {
+        val = val.values();
+      }
+    } else {
+      if (
+        prop.type === cassandra.types.Uuid ||
+        prop.type === 'Uuid' ||
+        prop.type.name === 'Uuid' ||
+        prop.type === cassandra.types.TimeUuid ||
+        prop.type === 'TimeUuid' ||
+        prop.type.name === 'TimeUuid'
+      ) {
         if (typeof val === 'string') {
-          val = JSON.parse(val);
+          val = val.toString();
         }
-        break;
-      default:
-        if (prop.type === Uuid || prop.type === 'Uuid' || prop.type.name === 'Uuid') {
-          if (typeof val !== 'string') {
-            val = val.toString();
-          }
-        } else if (!Array.isArray(prop.type) && !prop.type.modelName) {
-          // Do not convert array and model types
-          val = prop.type(val);
+      } else if (
+        prop.type === cassandra.types.Tuple ||
+        prop.type === 'Tuple' ||
+        prop.type.name === 'Tuple'
+      ) {
+        if (!Array.isArray(val)) {
+          val = val.values();
         }
-        break;
+      } else if (!Array.isArray(prop.type) && !prop.type.modelName) {
+        // Do not convert array and model types
+        val = prop.type(val);
+      }
     }
   }
   return val;
@@ -699,15 +775,19 @@ Cassandra.prototype.escapeName = function(name) {
  * @param {number} limit The limit
  * @returns {string} The LIMIT clause
  */
-Cassandra.prototype._buildLimit = function(model, limit) {
-  if (!limit || isNaN(limit)) {
+Cassandra.prototype._buildLimit = function(model, limit, offset) {
+  if (isNaN(limit)) {
+    limit = 0;
+  }
+  if (!limit) {
     return '';
   }
   return 'LIMIT ' + limit.toString();
 };
 
 Cassandra.prototype.applyPagination = function(model, stmt, filter) {
-  var limitClause = this._buildLimit(model, filter.limit);
+  var limitClause = this._buildLimit(model, filter.limit,
+    filter.offset || filter.skip);
   return stmt.merge(limitClause);
 };
 

--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -282,7 +282,7 @@ Cassandra.prototype.count = function(model, where, options, cb) {
   stmt.sql += ' ALLOW FILTERING';
   // CASS custom END
   stmt = this.parameterize(stmt);
-  this.execute(stmt.sql, serialize(stmt.params),
+  this.execute(stmt.sql, this.serialize(stmt.params),
     function(err, res) {
       if (err) {
         return cb(err);
@@ -338,7 +338,7 @@ Cassandra.prototype._modifyOrCreate = function(model, data, options, fields, cb)
  */
 Cassandra.prototype._replace = function(model, where, data, options, cb) {
   var stmt = this.buildReplace(model, where, data, options);
-  this.execute(stmt.sql, serialize(stmt.params), options, function(err, info) {
+  this.execute(stmt.sql, this.serialize(stmt.params), options, function(err, info) {
     return cb(err, info);
   });
 };
@@ -357,7 +357,7 @@ Cassandra.prototype.create = function(model, data, options, callback) {
   var stmt = this.buildInsert(model, data, options);
   var idColName = self.idColumn(model);
   if (!data[idColName]) data[idColName] = stmt.params[stmt.params.length - 1];
-  this.execute(stmt.sql, serialize(stmt.params), options, function(err, info) {
+  this.execute(stmt.sql, self.serialize(stmt.params), options, function(err, info) {
     if (err) {
       callback(err);
     } else {


### PR DESCRIPTION
This commit supports two pieces of functionality:

1. It refactors the types within the connector to be as closely aligned to the node cassandra-driver types.
2. It fixes an error when performing a POST with array values.

# 1)
The types used in Cassandra are:
    • asci
    • bigint
    • blob
    • Boolean
    • counter
    • decimal
    • double
    • float
    • inet
    • int
    • text
    • timestamp
    • timeuuid
    • uuid
    • varchar
    • varint
    • list
    • map
    • set
    • tuple

Many of the types have directly related types in JavaScript.
Most of the transformations are handle by the cassandra-driver,
however, the driver also provides JavaScript classes to represent
Cassandra types that are more complex (uuid, Tuple, etc).

The types that are represented by JavaScript classess need to be
set up as custom Loopback types. The changes within this commit
tries to keep those class types as unaltered as possible.

TODO: add BigDecimal, Long, InetAddress, Integer, LocalDate,
and LocalTime.

# 2)
The node cassandra-driver automatically handles the
transformation of arrays to the respective values within the
identified table a query is executing against (particularly
within update CQL statements). The default functionality
of the Loopback MySQL Connector converts array values to
JSON encoded strings. This is unecessary when using the
cassandra-driver