### PR TITLE
Add support for null data type

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -35,7 +35,7 @@ global.connectorCapabilities = {
   supportUpdateWithoutId: false,
   supportInclude: false,
   supportGeoPoint: false,
-  supportNullDataType: false
+  nullDataValueExists: false
 };
 
 global.sinon = require('sinon');

--- a/test/init.js
+++ b/test/init.js
@@ -35,6 +35,7 @@ global.connectorCapabilities = {
   supportUpdateWithoutId: false,
   supportInclude: false,
   supportGeoPoint: false,
+  supportNullDataType: false
 };
 
 global.sinon = require('sinon');


### PR DESCRIPTION
Since cassandra does not create a column in case of null or undefined or such for any type, we should add it as a `connector capability` to differentiate between other connectors.