### PR TITLE
Update cassandra.js

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -211,7 +211,7 @@ Cassandra.prototype.executeSQL = function(cql, params, options, callback) {
    return callback && callback(err, data ? data.rows : null);
   }
 
-  this.client.execute(cql, serialize(params), { prepare : true, readTimeout: 30000 }, myCallback);
+  this.client.execute(cql, serialize(params), { prepare : true, readTimeout: this.settings.readTimeout }, myCallback);
 };
 
 Cassandra.prototype.executeCQL = Cassandra.executeSQL;


### PR DESCRIPTION
### Description
If a query takes more than 30000 generates a timeout error

#### Related issues
The correction that is made is for the function to take the readTimeout from settings
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
