### PR TITLE
support for multiple cluster nodes

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -168,6 +168,8 @@ function generateOptions(settings) {
     clientOptions.contactPoints = [
       settings.hostname,
     ];
+  } else {
+      clientOptions.contactPoints = settings.contactPoints;
   }
 
   clientOptions.protocolOptions.port = settings.port;


### PR DESCRIPTION
support for multiple cluster nodes

### Description
Support for passing multiple cluster nodes as contact points.
Pass array of cluster nodes as contactPoints in the configuration. 


- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
