### PR TITLE
add support for sslOptions

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -172,6 +172,7 @@ function generateOptions(settings) {
 
   clientOptions.protocolOptions.port = settings.port;
   clientOptions.keyspace = settings.database;
+  clientOptions.sslOptions = settings.sslOptions;
 
   clientOptions.socketOptions.connectTimeout = settings.connectTimeout || 30000;
   clientOptions.socketOptions.readTimeout = settings.readTimeout || 30000;


### PR DESCRIPTION
### Description

The node cassandra driver supports SSL connections, but the options are not propagated. This simple pull request will simply add the sslOptions to the settings.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
