### PR TITLE
able to create non-existing keyspace

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -40,10 +40,22 @@ function timeUuidFromString(value) {
   return ret;
 }
 
+function tupleFromArray(value) {
+  var ret = null;
+  if (Array.isArray(value)) {
+    ret = originalTupleFromArray(value);
+  } else {
+    ret = value;
+  }
+  return ret;
+}
+
 var originalFromString = cassandra.types.Uuid.fromString;
 var originalTimeFromString = cassandra.types.TimeUuid.fromString;
+var originalTupleFromArray = cassandra.types.Tuple.fromArray;
 cassandra.types.Uuid.fromString = uuidFromString;
 cassandra.types.TimeUuid.fromString = timeUuidFromString;
+cassandra.types.Tuple.fromArray = tupleFromArray;
 
 function createKeyspace(settings, cb) {
   var options = generateOptions(settings);
@@ -604,6 +616,9 @@ Cassandra.prototype._serializeObject = serializeObject;
 
 function serializeObject(obj) {
   var val;
+  if (obj instanceof cassandra.types.Tuple) {
+    return obj;
+  }
   if (obj && typeof obj.toJSON === 'function') {
     obj = obj.toJSON();
   }

--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -57,24 +57,6 @@ cassandra.types.Uuid.fromString = uuidFromString;
 cassandra.types.TimeUuid.fromString = timeUuidFromString;
 cassandra.types.Tuple.fromArray = tupleFromArray;
 
-function createKeyspace(settings, cb) {
-  var options = generateOptions(settings);
-
-  var keyspaceName = options.keyspace;
-
-  if (options.keyspace) {
-    delete options.keyspace;
-  }
-
-  var client = new cassandra.Client(options);
-  var sql = 'CREATE KEYSPACE IF NOT EXISTS "' + keyspaceName +
-    '" WITH REPLICATION = ' + cassandraMAP.stringify(options.replication);
-
-  client.connect(function () {
-    client.execute(sql, cb);
-  });
-}
-
 /**
  * @module loopback-connector-cassandra
  *
@@ -97,11 +79,11 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
       });
     } else {
       if (dataSource.settings.createKeyspace) {
-         createKeyspace(dataSource.settings, function() {
+        dataSource.connector.createKeyspace(dataSource.settings, function() {
            dataSource.connector.connect(callback);
-         })
+        })
       } else {
-          dataSource.connector.connect(callback);
+        dataSource.connector.connect(callback);
       }
     }
   }
@@ -336,6 +318,26 @@ Cassandra.prototype.count = function(model, where, options, cb) {
       cb(err, Number(c));
     });
 };
+
+Cassandra.prototype.createKeyspace = function(settings, cb) {
+  var self = this;
+
+  var options = generateOptions(settings);
+
+  var keyspaceName = self.escapeName(options.keyspace);
+
+  if (options.keyspace) {
+    delete options.keyspace;
+  }
+
+  var client = new cassandra.Client(options);
+  var sql = 'CREATE KEYSPACE IF NOT EXISTS ' + keyspaceName +
+    ' WITH REPLICATION = ' + cassandraMAP.stringify(options.replication);
+
+  client.connect(function () {
+    client.execute(sql, cb);
+  });
+}
 
 Cassandra.prototype.generateMissingDefaults = function(model, data) {
   var props = this.getModelDefinition(model).properties;

--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -13,6 +13,7 @@ var cassandra = require('cassandra-driver');
 
 var SqlConnector = require('loopback-connector').SqlConnector;
 var ParameterizedSQL = SqlConnector.ParameterizedSQL;
+var cassandraMAP = require('cassandra-map');
 
 var debug = require('debug')('loopback:connector:cassandra');
 var debugQuery = require('debug')('loopback:connector:cassandra:query');
@@ -44,6 +45,24 @@ var originalTimeFromString = cassandra.types.TimeUuid.fromString;
 cassandra.types.Uuid.fromString = uuidFromString;
 cassandra.types.TimeUuid.fromString = timeUuidFromString;
 
+function createKeyspace(settings, cb) {
+  var options = generateOptions(settings);
+
+  var keyspaceName = options.keyspace;
+
+  if (options.keyspace) {
+    delete options.keyspace;
+  }
+
+  var client = new cassandra.Client(options);
+  var sql = 'CREATE KEYSPACE IF NOT EXISTS "' + keyspaceName +
+    '" WITH REPLICATION = ' + cassandraMAP.stringify(options.replication);
+
+  client.connect(function () {
+    client.execute(sql, cb);
+  });
+}
+
 /**
  * @module loopback-connector-cassandra
  *
@@ -65,7 +84,13 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
         callback();
       });
     } else {
-      dataSource.connector.connect(callback);
+      if (dataSource.settings.createKeyspace) {
+         createKeyspace(dataSource.settings, function() {
+           dataSource.connector.connect(callback);
+         })
+      } else {
+          dataSource.connector.connect(callback);
+      }
     }
   }
 };
@@ -181,6 +206,8 @@ function generateOptions(settings) {
   if (username && settings.password) {
     clientOptions.authProvider = new cassandra.auth.PlainTextAuthProvider(username, settings.password);
   }
+
+  clientOptions.replication = settings.replication || { class: 'SimpleStrategy', replication_factor: 3};
 
   return clientOptions;
 }
@@ -300,7 +327,7 @@ Cassandra.prototype.count = function(model, where, options, cb) {
 
 Cassandra.prototype.generateMissingDefaults = function(model, data) {
   var props = this.getModelDefinition(model).properties;
- 
+
   for (var i in props) {
     if (props.hasOwnProperty(i)) {
       var prop = props[i];

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var async = require('async');
+var cassandraMAP = require('cassandra-map');
 var f = require('util').format;
 module.exports = mixinMigration;
 
@@ -405,9 +406,14 @@ Cassandra.prototype.defineForeignKey = function(className, key, cb) {
   Cassandra.prototype.createTable = function(model, cb) {
     var self = this;
     var ksName = self.escapeName(self.dataSource.settings.keyspace);
+    var replication = self.dataSource.settings.replication ||  {
+      class: 'SimpleStrategy', 
+      replication_factor: 3,
+    };
+
     var sqlKeyspace = 'CREATE KEYSPACE IF NOT EXISTS ' + ksName +
-      ' WITH REPLICATION = { \'class\' : \'SimpleStrategy\',' +
-      ' \'replication_factor\' : \'3\' }';
+      ' WITH REPLICATION = ' + cassandraMAP.stringify(replication);
+
     self.execute(sqlKeyspace, function(err) {
       if (err) {
         return cb && cb(err);
@@ -492,7 +498,18 @@ Cassandra.prototype.defineForeignKey = function(className, key, cb) {
       case 'Boolean':
         return 'BOOLEAN'; // Cassandra doesn't have built-in boolean
       case 'tupleFromArray':
-        return 'TUPLE<' + prop.componentTypes.join() + '>';
+        function buildTupleDataType(tupleProp) {
+          var componentTypes = [];
+          tupleProp.componentTypes.forEach(function(componentType) {
+            var value = componentType;
+            if (typeof componentType === 'object' && componentType.type === 'Tuple') {
+              value = buildTupleDataType(componentType);
+            }
+            componentTypes.push(value);
+          });
+          return 'TUPLE<' + componentTypes.join() + '>';
+        }
+        return buildTupleDataType(prop);
     }
   };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -491,6 +491,8 @@ Cassandra.prototype.defineForeignKey = function(className, key, cb) {
         return 'POINT';
       case 'Boolean':
         return 'BOOLEAN'; // Cassandra doesn't have built-in boolean
+      case 'tupleFromArray':
+        return 'TUPLE<' + prop.componentTypes.join() + '>';
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-cassandra",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Loopback Cassandra Connector",
   "keywords": [
     "StrongLoop",
@@ -20,6 +20,7 @@
   "dependencies": {
     "async": "^2.3.0",
     "cassandra-driver": "^3.2.0",
+    "cassandra-map": "0.1.7",
     "debug": "^2.2.0",
     "loopback-connector": "^4.0.0",
     "strong-globalize": "^2.8.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "async": "^2.3.0",
-    "cassandra-driver": "^3.2.0",
+    "cassandra-driver": "3.5.0",
     "cassandra-map": "0.1.7",
     "debug": "^2.2.0",
     "loopback-connector": "^4.0.0",

--- a/test/cass.custom.test.js
+++ b/test/cass.custom.test.js
@@ -38,7 +38,7 @@ describe('cassandra custom tests', function() {
         },
       });
     CASS_TUPLE_TIME = db.define('CASS_TUPLE_TIME', {
-      tuple: {type: 'Tuple'},
+      tuple: {type: 'Tuple', componentTypes: ['TEXT', 'TEXT', 'TEXT', 'TEXT']},
       str: String,
       num: Number,
       time: {type: 'TimeUuid', id: true},
@@ -68,7 +68,7 @@ describe('cassandra custom tests', function() {
     m.patNum.should.equal(100);
     m.patStr.should.be.type('string');
     m.patStr.should.equal(cassTestString + '100');
- }
+  }
 
   describe('create keyspace if it does not exist', function () {
     it('create keysapce with no specified replication', function (done) {

--- a/test/cass.custom.test.js
+++ b/test/cass.custom.test.js
@@ -70,7 +70,7 @@ describe('cassandra custom tests', function() {
     m.patStr.should.equal(cassTestString + '100');
   }
 
-  describe.only('create keyspace if it does not exist', function () {
+  describe('create keyspace if it does not exist', function () {
     function queryKeyspace(connector, dsConfig, cb) {
       var ds = new DataSource(require('../'), dsConfig);
 

--- a/test/cass.custom.test.js
+++ b/test/cass.custom.test.js
@@ -70,14 +70,13 @@ describe('cassandra custom tests', function() {
     m.patStr.should.equal(cassTestString + '100');
   }
 
-  describe('create keyspace if it does not exist', function () {
+  describe.only('create keyspace if it does not exist', function () {
     function queryKeyspace(connector, dsConfig, cb) {
       var ds = new DataSource(require('../'), dsConfig);
 
       connector.initialize(ds, function () {
-        ds.connector.execute('SELECT replication FROM system_schema.keyspaces WHERE keyspace_name=\'' + dsConfig.keyspace + '\'', function (err, rows) {
-          cb(err, rows);
-        });
+        ds.connector.execute('SELECT replication FROM system_schema.keyspaces' +
+          ' WHERE keyspace_name=\'' + dsConfig.keyspace + '\'', cb);
       });
     }
 

--- a/test/cass.custom.test.js
+++ b/test/cass.custom.test.js
@@ -38,7 +38,7 @@ describe('cassandra custom tests', function() {
         },
       });
     CASS_TUPLE_TIME = db.define('CASS_TUPLE_TIME', {
-      tuple: {type: 'Tuple', componentTypes: ['TEXT', 'TEXT', 'TEXT', 'TEXT']},
+      tuple: {type: 'Tuple', componentTypes: [{type: 'Tuple', componentTypes: ['TEXT', 'TEXT']}, 'TEXT', 'TEXT', 'TEXT']},
       str: String,
       num: Number,
       time: {type: 'TimeUuid', id: true},
@@ -359,7 +359,7 @@ describe('cassandra custom tests', function() {
   });
 
   var ID_2, savedTuple, savedTimeUuid;
-  var origTupleArray = ['USA', 'California', 'San Francisco', 'Market St.'];
+  var origTupleArray = [cassandra.types.Tuple.fromArray(['USA', 'California']), 'San Francisco', 'Market', 'St.'];
   var origTuple = cassandra.types.Tuple.fromArray(origTupleArray);
   var origTimeUuid = cassandra.types.TimeUuid.now();
 

--- a/test/init.js
+++ b/test/init.js
@@ -8,7 +8,11 @@ var DataSource = require('loopback-datasource-juggler').DataSource;
 var config = require('rc')('loopback', {test: {cassandra: {
   host: process.env.CASSANDRA_HOST || 'localhost',
   port: process.env.CASSANDRA_PORT || 9042,
-  keyspace: process.env.CASSANDRA_KEYSPACE || 'test'
+  keyspace: process.env.CASSANDRA_KEYSPACE || 'test',
+  replication: process.env.CASSANDRA_REPLICATION || {
+    class: 'SimpleStrategy', 
+    replication_factor: 3,
+  }
 }}}).test.cassandra;
 
 global.getDataSource = global.getSchema = function() {


### PR DESCRIPTION
### Description
I'm looking at using cassandra as our database and build app using loopback. Current loopback-connector-cassandra can not create keyspace if it doesn't exist. It might be the design that it is expected to create keysapce instead of letting app to create it itself. But it will be more convenient if loopback-connector-cassandra has the capability. 

So I add the following setting to DataSource setting
* createKeyspace: true to create keyspace. Otherwise do not like it is today
* replication: object to define replication setting. e.g.
```
            replication: {
              class: 'NetworkTopologyStrategy', 
              dc1: 1,
            }
```

Please review the PR to see if it can be merged. Any change needed please let me know. 

So I fixed the failure test about tuple by adding support of Tuple.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <https://github.com/strongloop/loopback-connector-cassandra/issues/24>
- connect to <https://github.com/strongloop/loopback-connector-cassandra/issues/10>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
