### PR TITLE
Default to TEXT. Dropping using VARCHAR

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -483,7 +483,6 @@ Cassandra.prototype.defineForeignKey = function(className, key, cb) {
       default:
       case 'String':
       case 'JSON':
-        return 'VARCHAR';
       case 'Text':
         return 'TEXT';
       case 'Number':


### PR DESCRIPTION
### Description
When defining property in model using 'String' or 'JSON', current code uses `VARCHAR` as datatype. However cassandra always uses `TEXT` to define the column.  E.g. `create table "test" ( id uuid primary key, value VARCHAR);` generates table 

```
cqlsh:test> desc table "test";

CREATE TABLE test.test (
    id uuid PRIMARY KEY,
    value text
) WITH bloom_filter_fp_chance = 0.01
...
```

Thus, when doing `autoupdate`, loopback-connector-cassandra always thinks there is schema change as the datatype is `VARCHAR` from model definition while it is `TEXT` from database. 

In Cassandra, varchar is a synonym for text. From https://datastax-oss.atlassian.net/browse/JAVA-402, I think loopback-connector-cassandra should drop using `VARCHAR` to avoid unnecessary issue like migration. 

Also Cassandra dropping support to alter column type today. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
