### PR TITLE
Support Collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 node_modules
 dist
 *xunit.xml
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
+  - 10
 addons:
   apt:
     sources:

--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -233,7 +233,8 @@ Cassandra.prototype.executeSQL = function(cql, params, options, callback) {
    return callback && callback(err, data ? data.rows : null);
   }
 
-  this.client.execute(cql, serialize(params), { prepare : true, readTimeout: 30000 }, myCallback);
+  this.client.execute(cql, serialize(params), 
+    { prepare : true, readTimeout: 30000 }, myCallback);
 };
 
 Cassandra.prototype.executeCQL = Cassandra.executeSQL;
@@ -392,6 +393,28 @@ Cassandra.prototype._replace = function(model, where, data, options, cb) {
 };
 
 /**
+ * Internal helper function. Cassandra client need object for collection 
+ * data type. Since Cassandra connector extends from SqlConnector and 
+ * SqlConnector converts all objects to string, this helper function is 
+ * used to revert collection type of data to object.
+ * 
+ * @param {String} model name of the model 
+ * @param {Object} data data to be used as sql values.
+ */
+Cassandra.prototype._restoreToObject = function(model, data) {
+  var res = {};
+  for (var propName in data) {
+    var type = this.columnDataType(model, propName);
+    if (isCassandraCollection(type) && typeof data[propName] === 'string') {
+      res[propName] = JSON.parse(data[propName]);
+    } else {
+      res[propName] = data[propName];
+    }
+  }
+  return res;
+}
+
+/**
  * Create the data model in Cassandra
  *
  * @param {String} model The model name
@@ -401,6 +424,7 @@ Cassandra.prototype._replace = function(model, where, data, options, cb) {
  */
 Cassandra.prototype.create = function(model, data, options, callback) {
   var self = this;
+  data = this._restoreToObject(model, data); // Due to SqlConnector stringify Arry, Object, JSON.
   data = this.generateMissingDefaults(model, data);
   var stmt = this.buildInsert(model, data, options);
   var idColName = self.idColumn(model);
@@ -419,6 +443,22 @@ Cassandra.prototype.create = function(model, data, options, callback) {
       callback(err, insertedId);
     }
   });
+};
+
+/**
+ * Update attributes for a given model instance
+ * 
+ * @param {String} model The model name
+ * @param {*} id The id value
+ * @param {Object} data The model data instance containing all properties to
+ * be updated
+ * @param {Object} options Options object
+ * @param {Function} cb The callback function
+ * @private
+ */
+Cassandra.prototype.updateAttributes = function(model, id, data, options, cb) {
+  data = this._restoreToObject(model, data);
+  SqlConnector.prototype.updateAttributes.call(this, model, id, data, options, cb);
 };
 
 /**
@@ -444,6 +484,22 @@ Cassandra.prototype.buildReplaceFields = function(model, data, excludeIds) {
  */
 Cassandra.prototype.buildFields = function(model, data, excludeIds) {
   var keys = Object.keys(data);
+
+  var self = this;
+  keys.forEach(function(key) {
+    var kv = data[key];
+    if (kv && typeof kv === 'object') {
+      var type = self.columnDataType(model, key);
+      if (!kv.getDataType) {
+        Object.defineProperty(kv, 'getDataType', {
+          value: function() {
+            return type;
+          },
+        });
+      }
+    }
+  })
+
   return this._buildFieldsForKeys(model, data, keys, excludeIds);
 };
 
@@ -603,10 +659,11 @@ Cassandra.prototype.toColumnValue = function(prop, val) {
     return val;
   }
   if (prop.type.name === 'Array' || prop.type.name === 'List') {
-    return JSON.stringify(val);
+    return val;
   }
-  if (prop.type === Object) {
-    return this._serializeObject(val);
+  if (prop.type === Object || Array.isArray(prop.type)) {
+    var type = (prop.cassandra && prop.cassandra.dataType) ? prop.cassandra.dataType.toUpperCase() : '';
+    return isCassandraCollection(type) ? val : this._serializeObject(val);
   }
   if (typeof prop.type === 'function') {
     return prop.type(val);
@@ -624,13 +681,23 @@ function serializeObject(obj) {
   if (obj && typeof obj.toJSON === 'function') {
     obj = obj.toJSON();
   }
+
   if (obj && typeof obj !== 'string') {
-    // avoid to stringify null and undefined
-    val = JSON.stringify(obj);
+    if(obj.getDataType && typeof obj.getDataType === 'function') {
+      var type = obj.getDataType();
+      val = isCassandraCollection(type) ? obj : JSON.stringify(obj);
+    } else {
+      val = JSON.stringify(obj);
+    }
   } else {
     val = obj;
   }
   return val;
+}
+
+function isCassandraCollection(dataType) {
+  return dataType && (dataType.startsWith('LIST') || 
+    dataType.startsWith('SET') || dataType.startsWith('MAP'));
 }
 
 function serialize(params) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -483,7 +483,6 @@ Cassandra.prototype.defineForeignKey = function(className, key, cb) {
       default:
       case 'String':
       case 'JSON':
-        return 'VARCHAR';
       case 'Text':
         return 'TEXT';
       case 'Number':


### PR DESCRIPTION
### Description
We need use Cassandra collections. Current cassandra connector doesn't support to define table using collections, as well as inserting/updating column of collection type. This PR adds capabilities to 

1. Define model property to be collection type
In general, `cassandra.dataType` is required for cassandra connector to understand what type of cassandra dataType should be used.  If `cassandra.dataType`  is not set, cassandra connector will infer cassandra dataType from loopback data type, e.g. String is mapped to TEXT, Array/Object is mapped to TEXT. E.g. `data: [String]` is a TEXT in cassandra db, while `data: { type: [String], cassandra: {dataType: 'Set<Text>'}}` is a Set in cassandra.  The reason that Array/Object is not mapped to collection when `cassandra.dataType` is not set is because cassandra connector extends SqlConnector which convert Array/Object to string. A lot of tests from `loopback-datasource-juggler/test/common.batch.js` and `loopback-datasource-juggler/test/include.test.js` will fail if we change this behavior. 

Note that: nested collections is not fully supported in this PR. It can be used to define model. But there is error to insert/update it. For now, I don't think nested collection is used frequently. So it can be deferred. 

- List
```
       listData: {
          type: [String],
          cassandra: {
            dataType: 'List<Text>'
          }
        },
```
- Set
```
        setData: {
          type: Array,
          cassandra: {
            dataType: 'Set<Text>'
          }
        },
```
- Map
```
        mapData: {
          type: Object,
          cassandra: {
            dataType: 'Map<Text, Text>'
          }
        },
```

2. Insert/update collection type of data
Note that the column data is updated as a whole. Special operations of collections will be added later. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cassandra/issues/60

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
