### PR TITLE
Add support to composite keys for updateAttributes

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -354,6 +354,47 @@ Cassandra.prototype.generateMissingDefaults = function(model, data) {
   return data;
 };
 
+/**
+ * Get name of cluster Ids for the model
+ * @param {string} model name of model
+ */
+Cassandra.prototype.clusterIdNames = function(model) {
+  var idNames = [];
+  var settings = this.dataSource.models[model].settings.cassandra;
+  if (settings && Array.isArray(settings.clusteringKeys)) {
+    settings.clusteringKeys.forEach(function(prop) {
+      var parts = [];
+      prop.split(' ').forEach(function(part) {
+        if (part) parts.push(part);
+      });
+      idNames.push(parts[0]);
+    });
+  }
+  return idNames;
+}
+
+/*
+ * Override SqlConnector.prototype._buildFieldsForKeys so that cluster ids
+ * are excluded when excludeIds is true
+ * @param {String} model The model name.
+ * @returns {Object} data The model data object.
+ * @returns {Array} keys The key fields for which need to be built.
+ * @param {Boolean} excludeIds Exclude id properties or not, default to false
+ * @private
+ */
+Cassandra.prototype._buildFieldsForKeys = function(model, data, keys, excludeIds) {
+  // Remove cluster Ids from keys if excludeIds is true
+  var clusterIdNames = this.clusterIdNames(model);
+  var validKeys = keys;
+  if (excludeIds ) {
+    validKeys = keys.filter(function(element) {
+      return clusterIdNames.indexOf(element) === -1;
+    });
+  }
+
+  return SqlConnector.prototype._buildFieldsForKeys.call(this, model, data, validKeys, excludeIds);
+};
+
 Cassandra.prototype._modifyOrCreate = function(model, data, options, fields, cb) {
   // data = this.generateMissingDefaults(model, data);
   var sql = new ParameterizedSQL('INSERT INTO ' + this.tableEscaped(model));
@@ -459,6 +500,34 @@ Cassandra.prototype.create = function(model, data, options, callback) {
 Cassandra.prototype.updateAttributes = function(model, id, data, options, cb) {
   data = this._restoreToObject(model, data);
   SqlConnector.prototype.updateAttributes.call(this, model, id, data, options, cb);
+};
+
+/*
+ * @param model The model name.
+ * @param id The instance ID.
+ * @param {Object} data The data Object.
+ * @returns {Object} where The where object for a spcific instance.
+ * @private
+ */
+Cassandra.prototype._buildWhereObjById = function(model, id, data) {
+  var idName = this.idName(model); 
+  delete data[idName];
+  var where = {};
+  where[idName] = id;
+
+  // For composite primay keys, ideally they should be passed in as `id`
+  // For now, just pick them from `data`
+  var idNames = this.idNames(model); 
+  Array.prototype.push.apply(idNames, this.clusterIdNames(model));
+
+  idNames.map(function(element) {
+    if (data[element]) {
+      where[element] = data[element];
+      delete data[element];
+    }
+  });
+
+  return where;
 };
 
 /**

--- a/test/cass.custom.test.js
+++ b/test/cass.custom.test.js
@@ -207,6 +207,7 @@ describe('cassandra custom tests', function() {
   });
 
   var ID_1;
+  var ROW_1;
 
   it('create sortable 1', function(done) {
     CASS_SORTABLE.create({
@@ -224,6 +225,7 @@ describe('cassandra custom tests', function() {
         patNum: 100,
         patBool: true });
       ID_1 = m.id;
+      ROW_1 = m;
       done();
     });
   });
@@ -358,6 +360,178 @@ describe('cassandra custom tests', function() {
         rows[1].num.should.be.eql(50);
         done();
       });
+  });
+
+  it('update attributes', function(done) {
+    ROW_1.updateAttributes({ 
+      str: ROW_1.str,
+      num: ROW_1.num,
+      patBool: ROW_1.patBool,
+      patNum: ROW_1.patNum,
+      patStr: ROW_1.patStr,
+      yearMonth: '2018-06'}, function(err, row) {
+        should.not.exist(err);
+        should.equal(row.str, ROW_1.str);
+        should.equal(row.num, ROW_1.num);
+        should.equal(row.partNum, ROW_1.partNum);
+        should.equal(row.partBool, ROW_1.partBool);
+        should.equal(row.yearMonth, '2018-06');
+        should.equal(row.partStr, ROW_1.partStr);
+        done();
+      });
+  });
+
+  it('replace attributes', function(done) {
+    ROW_1.replaceAttributes({ 
+      str: ROW_1.str,
+      num: ROW_1.num,
+      patBool: ROW_1.patBool,
+      patNum: ROW_1.patNum,
+      patStr: ROW_1.patStr,
+      yearMonth: '2018-07'}, function(err, row) {
+        should.not.exist(err);
+        should.equal(row.str, ROW_1.str);
+        should.equal(row.num, ROW_1.num);
+        should.equal(row.partNum, ROW_1.partNum);
+        should.equal(row.partBool, ROW_1.partBool);
+        should.equal(row.yearMonth, '2018-07');
+        should.equal(row.partStr, ROW_1.partStr);
+        done();
+      });
+  });
+
+  it('updateAll should work with composite keys', function(done) {
+    var data = {
+      str: ROW_1.str,
+      num: ROW_1.num,
+      patBool: ROW_1.patBool,
+      patStr: ROW_1.patStr,
+      yearMonth: '2018-01'};
+    CASS_SORTABLE.updateAll({patNum: ROW_1.patNum, 
+      patStr: ROW_1.patStr, 
+      patBool: ROW_1.patBool,
+      num: ROW_1.num,
+      str: data.str}, data, function(err, row) {
+      should.not.exist(err);
+      should.not.exist(row.count);
+      done();
+    });
+  });
+
+  // https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid
+  it('replaceById should work with composite keys', function(done) {
+    var data = {
+      str: ROW_1.str,
+      num: ROW_1.num,
+      patBool: ROW_1.patBool,
+      patNum: ROW_1.patNum,
+      yearMonth: '2018-05'};
+    CASS_SORTABLE.replaceById(ROW_1.patStr, data, function(err, row) {
+      should.not.exist(err);
+      should.equal(row.str, data.str);
+      should.equal(row.num, data.num);
+      should.equal(row.partNum, data.partNum);
+      should.equal(row.partBool, data.partBool);
+      should.equal(row.yearMonth, data.yearMonth);
+      should.equal(row.partStr, data.partStr);      
+      done();
+    });
+  });
+
+  // https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate
+  it('replaceOrCreate should work with composite keys', function(done) {
+    var data = {
+      str: uuid.v1(),
+      num: 70,
+      patBool: false,
+      patNum: 100,
+      patStr: uuid.v1(),
+      yearMonth: '2018-03'};
+    CASS_SORTABLE.replaceOrCreate(data, function(err, row) {
+      should.not.exist(err);
+      should.equal(row.str, data.str);
+      should.equal(row.num, data.num);
+      should.equal(row.partNum, data.partNum);
+      should.equal(row.partBool, data.partBool);
+      should.equal(row.yearMonth, data.yearMonth);
+      should.equal(row.partStr, data.partStr);
+
+      data.yearMonth = '2018-02';
+      CASS_SORTABLE.replaceOrCreate(data, function(err, row) {
+        should.not.exist(err);
+        should.equal(row.str, data.str);
+        should.equal(row.num, data.num);
+        should.equal(row.partNum, data.partNum);
+        should.equal(row.partBool, data.partBool);
+        should.equal(row.yearMonth, data.yearMonth);
+        should.equal(row.partStr, data.partStr);
+        done();
+      });
+    });
+  });  
+
+  // https://apidocs.strongloop.com/loopback/#persistedmodel-upsert
+  it('upsert should work with composite keys', function(done) {
+    var data = {
+      str: uuid.v1(),
+      num: 70,
+      patBool: false,
+      patNum: 100,
+      patStr: uuid.v1(),
+      yearMonth: '2018-01'};
+    CASS_SORTABLE.upsert(data, function(err, row) {
+      should.not.exist(err);
+      should.equal(row.str, data.str);
+      should.equal(row.num, data.num);
+      should.equal(row.partNum, data.partNum);
+      should.equal(row.partBool, data.partBool);
+      should.equal(row.yearMonth, data.yearMonth);
+      should.equal(row.partStr, data.partStr);
+
+      data.yearMonth = '2018-02';
+      CASS_SORTABLE.upsert(data, function(err, row) {
+        should.not.exist(err);
+        should.equal(row.str, data.str);
+        should.equal(row.num, data.num);
+        should.equal(row.partNum, data.partNum);
+        should.equal(row.partBool, data.partBool);
+        should.equal(row.yearMonth, data.yearMonth);
+        should.equal(row.partStr, data.partStr);
+        done();
+      });
+    });
+  });
+
+   // https://apidocs.strongloop.com/loopback/#persistedmodel-upsertwithwhere
+   it('upsertWithWhere should work with composite keys', function(done) {
+    var data = {
+      str: uuid.v1(),
+      num: 80,
+      patBool: false,
+      patNum: 200,
+      patStr: uuid.v1(),
+      yearMonth: '2018-03'};
+    CASS_SORTABLE.upsertWithWhere({patNum: 200}, data, function(err, row) {
+      should.not.exist(err);
+      should.equal(row.str, data.str);
+      should.equal(row.num, data.num);
+      should.equal(row.partNum, data.partNum);
+      should.equal(row.partBool, data.partBool);
+      should.equal(row.yearMonth, data.yearMonth);
+      should.equal(row.partStr, data.partStr);
+
+      data.yearMonth = '2018-04';
+      CASS_SORTABLE.upsert(data, function(err, row) {
+        should.not.exist(err);
+        should.equal(row.str, data.str);
+        should.equal(row.num, data.num);
+        should.equal(row.partNum, data.partNum);
+        should.equal(row.partBool, data.partBool);
+        should.equal(row.yearMonth, data.yearMonth);
+        should.equal(row.partStr, data.partStr);
+        done();
+      });
+    });
   });
 
   var ID_2, savedTuple, savedTimeUuid;


### PR DESCRIPTION
### Description
When using updateAttributes and the passed data contains primary columns (including partition keys and clustering keys), it failed w/ the error below. (See related issue for details). 

Uncaught AssertionError: expected ResponseError {
  name: 'ResponseError',
  info: 'Represents an error message from the server',
  message: 'PRIMARY KEY part str found in SET part',
  code: 8704,
  query: 'UPDATE "CASS_SORTABLE" SET "str"=?,"num"=?,"yearMonth"=? WHERE "patStr"=?'
} to not exist

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cassandra/issues/61

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
