### PR TITLE
load updated record after update in order to adapt to change of juggler.3.22.1

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -387,7 +387,13 @@ Cassandra.prototype._modifyOrCreate = function(model, data, options, fields, cb)
  */
 Cassandra.prototype._replace = function(model, where, data, options, cb) {
   var stmt = this.buildReplace(model, where, data, options);
+  var self = this;
   this.execute(stmt.sql, serialize(stmt.params), options, function(err, info) {
+    if (!err && !info) {
+      return self.all(model, {where: where}, options, function(findErr, result) {
+        return cb(findErr, result[0]);
+      });
+    }
     return cb(err, info);
   });
 };


### PR DESCRIPTION
### Description
The root cause is described in https://github.com/strongloop/loopback-connector-cassandra/issues/65. The solution is to load updated record from db. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cassandra/issues/65

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
