### PR TITLE
fix issue where settings.contactPoints not used

### DIFF
--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -183,7 +183,9 @@ function generateOptions(settings) {
   settings.port = (settings.port || 9042);
   settings.database = (settings.keyspace || settings.database || settings.db || 'test');
 
-  if (!settings.contactPoints) {
+  if (settings.contactPoints) {
+    clientOptions.contactPoints = settings.contactPoints ;
+  } else {
     clientOptions.contactPoints = [
       settings.hostname,
     ];

--- a/lib/cassandra.js
+++ b/lib/cassandra.js
@@ -184,7 +184,7 @@ function generateOptions(settings) {
   settings.database = (settings.keyspace || settings.database || settings.db || 'test');
 
   if (settings.contactPoints) {
-    clientOptions.contactPoints = settings.contactPoints ;
+    clientOptions.contactPoints = settings.contactPoints;
   } else {
     clientOptions.contactPoints = [
       settings.hostname,


### PR DESCRIPTION
### Description
Use settings parameter contactPoints for cassandra client options if provided.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

If settings.contactPoints has been provided, the clientOptions is initialized without any hosts.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
