### PR TITLE
migration failed drop multiple columns case

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -273,7 +273,7 @@ function mixinMigration(Cassandra) {
         return;
       }
       if (actualFieldNotPresentInModel(actualField, model)) {
-        sqlColumn.push('DROP ' + self.escapeName(actualField.column));
+        sqlColumn.push(self.escapeName(actualField.column));
       }
     });
     if (sqlColumn.length > 0) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -266,17 +266,18 @@ function mixinMigration(Cassandra) {
 
   Cassandra.prototype.getColumnsToDrop = function(model, actualFields) {
     var self = this;
+    var sqlColumn = [];
     var sql = [];
     actualFields.forEach(function(actualField) {
       if (self.idColumn(model) === actualField.column) {
         return;
       }
       if (actualFieldNotPresentInModel(actualField, model)) {
-        sql.push('DROP ' + self.escapeName(actualField.column));
+        sqlColumn.push('DROP ' + self.escapeName(actualField.column));
       }
     });
-    if (sql.length > 0) {
-      sql = [sql.join(', ')];
+    if (sqlColumn.length > 0) {
+      sql = ['DROP (' + sqlColumn.join(', ') + ')'];
     }
     return sql;
 


### PR DESCRIPTION
### Description
migration tables that have multiple drop columns do not work.

#### Related issues
- connect to #81

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
